### PR TITLE
Replace Available Klak Scripts

### DIFF
--- a/Scripts/Assembly-CSharp/Klak/Math/Perlin.cs
+++ b/Scripts/Assembly-CSharp/Klak/Math/Perlin.cs
@@ -1,84 +1,194 @@
+//
+// Klak - Utilities for creative coding with Unity
+//
+// Copyright (C) 2016 Keijiro Takahashi
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+//
+// This script is based on the original implementation by Ken Perlin
+// http://mrl.nyu.edu/~perlin/noise/
+//
+
 using UnityEngine;
 
 namespace Klak.Math
 {
-	public static class Perlin
-	{
-		private static int[] perm;
+    public static class Perlin
+    {
+        #region Noise functions
 
-		public static float Noise(float x)
-		{
-			return 0f;
-		}
+        public static float Noise(float x)
+        {
+            var X = Mathf.FloorToInt(x) & 0xff;
+            x -= Mathf.Floor(x);
+            var u = Fade(x);
+            return Lerp(u, Grad(perm[X], x), Grad(perm[X+1], x-1)) * 2;
+        }
 
-		public static float Noise(float x, float y)
-		{
-			return 0f;
-		}
+        public static float Noise(float x, float y)
+        {
+            var X = Mathf.FloorToInt(x) & 0xff;
+            var Y = Mathf.FloorToInt(y) & 0xff;
+            x -= Mathf.Floor(x);
+            y -= Mathf.Floor(y);
+            var u = Fade(x);
+            var v = Fade(y);
+            var A = (perm[X  ] + Y) & 0xff;
+            var B = (perm[X+1] + Y) & 0xff;
+            return Lerp(v, Lerp(u, Grad(perm[A  ], x, y  ), Grad(perm[B  ], x-1, y  )),
+                           Lerp(u, Grad(perm[A+1], x, y-1), Grad(perm[B+1], x-1, y-1)));
+        }
 
-		public static float Noise(Vector2 coord)
-		{
-			return 0f;
-		}
+        public static float Noise(Vector2 coord)
+        {
+            return Noise(coord.x, coord.y);
+        }
 
-		public static float Noise(float x, float y, float z)
-		{
-			return 0f;
-		}
+        public static float Noise(float x, float y, float z)
+        {
+            var X = Mathf.FloorToInt(x) & 0xff;
+            var Y = Mathf.FloorToInt(y) & 0xff;
+            var Z = Mathf.FloorToInt(z) & 0xff;
+            x -= Mathf.Floor(x);
+            y -= Mathf.Floor(y);
+            z -= Mathf.Floor(z);
+            var u = Fade(x);
+            var v = Fade(y);
+            var w = Fade(z);
+            var A  = (perm[X  ] + Y) & 0xff;
+            var B  = (perm[X+1] + Y) & 0xff;
+            var AA = (perm[A  ] + Z) & 0xff;
+            var BA = (perm[B  ] + Z) & 0xff;
+            var AB = (perm[A+1] + Z) & 0xff;
+            var BB = (perm[B+1] + Z) & 0xff;
+            return Lerp(w, Lerp(v, Lerp(u, Grad(perm[AA  ], x, y  , z  ), Grad(perm[BA  ], x-1, y  , z  )),
+                                   Lerp(u, Grad(perm[AB  ], x, y-1, z  ), Grad(perm[BB  ], x-1, y-1, z  ))),
+                           Lerp(v, Lerp(u, Grad(perm[AA+1], x, y  , z-1), Grad(perm[BA+1], x-1, y  , z-1)),
+                                   Lerp(u, Grad(perm[AB+1], x, y-1, z-1), Grad(perm[BB+1], x-1, y-1, z-1))));
+        }
 
-		public static float Noise(Vector3 coord)
-		{
-			return 0f;
-		}
+        public static float Noise(Vector3 coord)
+        {
+            return Noise(coord.x, coord.y, coord.z);
+        }
 
-		public static float Fbm(float x, int octave)
-		{
-			return 0f;
-		}
+        #endregion
 
-		public static float Fbm(Vector2 coord, int octave)
-		{
-			return 0f;
-		}
+        #region fBm functions
 
-		public static float Fbm(float x, float y, int octave)
-		{
-			return 0f;
-		}
+        public static float Fbm(float x, int octave)
+        {
+            var f = 0.0f;
+            var w = 0.5f;
+            for (var i = 0; i < octave; i++) {
+                f += w * Noise(x);
+                x *= 2.0f;
+                w *= 0.5f;
+            }
+            return f;
+        }
 
-		public static float Fbm(Vector3 coord, int octave)
-		{
-			return 0f;
-		}
+        public static float Fbm(Vector2 coord, int octave)
+        {
+            var f = 0.0f;
+            var w = 0.5f;
+            for (var i = 0; i < octave; i++) {
+                f += w * Noise(coord);
+                coord *= 2.0f;
+                w *= 0.5f;
+            }
+            return f;
+        }
 
-		public static float Fbm(float x, float y, float z, int octave)
-		{
-			return 0f;
-		}
+        public static float Fbm(float x, float y, int octave)
+        {
+            return Fbm(new Vector2(x, y), octave);
+        }
 
-		private static float Fade(float t)
-		{
-			return 0f;
-		}
+        public static float Fbm(Vector3 coord, int octave)
+        {
+            var f = 0.0f;
+            var w = 0.5f;
+            for (var i = 0; i < octave; i++) {
+                f += w * Noise(coord);
+                coord *= 2.0f;
+                w *= 0.5f;
+            }
+            return f;
+        }
 
-		private static float Lerp(float t, float a, float b)
-		{
-			return 0f;
-		}
+        public static float Fbm(float x, float y, float z, int octave)
+        {
+            return Fbm(new Vector3(x, y, z), octave);
+        }
 
-		private static float Grad(int hash, float x)
-		{
-			return 0f;
-		}
+        #endregion
 
-		private static float Grad(int hash, float x, float y)
-		{
-			return 0f;
-		}
+        #region Private functions
 
-		private static float Grad(int hash, float x, float y, float z)
-		{
-			return 0f;
-		}
-	}
+        static float Fade(float t)
+        {
+            return t * t * t * (t * (t * 6 - 15) + 10);
+        }
+
+        static float Lerp(float t, float a, float b)
+        {
+            return a + t * (b - a);
+        }
+
+        static float Grad(int hash, float x)
+        {
+            return (hash & 1) == 0 ? x : -x;
+        }
+
+        static float Grad(int hash, float x, float y)
+        {
+            return ((hash & 1) == 0 ? x : -x) + ((hash & 2) == 0 ? y : -y);
+        }
+
+        static float Grad(int hash, float x, float y, float z)
+        {
+            var h = hash & 15;
+            var u = h < 8 ? x : y;
+            var v = h < 4 ? y : (h == 12 || h == 14 ? x : z);
+            return ((h & 1) == 0 ? u : -u) + ((h & 2) == 0 ? v : -v);
+        }
+
+        static int[] perm = {
+            151,160,137,91,90,15,
+            131,13,201,95,96,53,194,233,7,225,140,36,103,30,69,142,8,99,37,240,21,10,23,
+            190, 6,148,247,120,234,75,0,26,197,62,94,252,219,203,117,35,11,32,57,177,33,
+            88,237,149,56,87,174,20,125,136,171,168, 68,175,74,165,71,134,139,48,27,166,
+            77,146,158,231,83,111,229,122,60,211,133,230,220,105,92,41,55,46,245,40,244,
+            102,143,54, 65,25,63,161, 1,216,80,73,209,76,132,187,208, 89,18,169,200,196,
+            135,130,116,188,159,86,164,100,109,198,173,186, 3,64,52,217,226,250,124,123,
+            5,202,38,147,118,126,255,82,85,212,207,206,59,227,47,16,58,17,182,189,28,42,
+            223,183,170,213,119,248,152, 2,44,154,163, 70,221,153,101,155,167, 43,172,9,
+            129,22,39,253, 19,98,108,110,79,113,224,232,178,185, 112,104,218,246,97,228,
+            251,34,242,193,238,210,144,12,191,179,162,241, 81,51,145,235,249,14,239,107,
+            49,192,214, 31,181,199,106,157,184, 84,204,176,115,121,50,45,127, 4,150,254,
+            138,236,205,93,222,114,67,29,24,72,243,141,128,195,78,66,215,61,156,180,
+            151
+        };
+
+        #endregion
+    }
 }

--- a/Scripts/Assembly-CSharp/Klak/Motion/BrownianMotion.cs
+++ b/Scripts/Assembly-CSharp/Klak/Motion/BrownianMotion.cs
@@ -1,173 +1,175 @@
+//
+// Klak - Utilities for creative coding with Unity
+//
+// Copyright (C) 2016 Keijiro Takahashi
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
 using UnityEngine;
+using Klak.Math;
 
 namespace Klak.Motion
 {
-	public class BrownianMotion : MonoBehaviour
-	{
-		[SerializeField]
-		private bool _enablePositionNoise;
+    [AddComponentMenu("Klak/Motion/Brownian Motion")]
+    public class BrownianMotion : MonoBehaviour
+    {
+        #region Editable Properties
 
-		[SerializeField]
-		private bool _enableRotationNoise;
+        [SerializeField] bool _enablePositionNoise = true;
+        [SerializeField] bool _enableRotationNoise = true;
 
-		[SerializeField]
-		private float _positionFrequency;
+        [SerializeField] float _positionFrequency = 0.2f;
+        [SerializeField] float _rotationFrequency = 0.2f;
 
-		[SerializeField]
-		private float _rotationFrequency;
+        [SerializeField] float _positionAmplitude = 0.5f;
+        [SerializeField] float _rotationAmplitude = 10.0f;
 
-		[SerializeField]
-		private float _positionAmplitude;
+        [SerializeField] Vector3 _positionScale = Vector3.one;
+        [SerializeField] Vector3 _rotationScale = new Vector3(1, 1, 0);
 
-		[SerializeField]
-		private float _rotationAmplitude;
+        [SerializeField, Range(0, 8)] int _positionFractalLevel = 3;
+        [SerializeField, Range(0, 8)] int _rotationFractalLevel = 3;
 
-		[SerializeField]
-		private Vector3 _positionScale;
+        #endregion
 
-		[SerializeField]
-		private Vector3 _rotationScale;
+        #region Public Properties And Methods
 
-		[SerializeField]
-		[Range(0f, 8f)]
-		private int _positionFractalLevel;
+        public bool enablePositionNoise {
+            get { return _enablePositionNoise; }
+            set { _enablePositionNoise = value; }
+        }
 
-		[SerializeField]
-		[Range(0f, 8f)]
-		private int _rotationFractalLevel;
+        public bool enableRotationNoise {
+            get { return _enableRotationNoise; }
+            set { _enableRotationNoise = value; }
+        }
 
-		private const float _fbmNorm = 1.3333334f;
+        public float positionFrequency {
+            get { return _positionFrequency; }
+            set { _positionFrequency = value; }
+        }
 
-		private Vector3 _initialPosition;
+        public float rotationFrequency {
+            get { return _rotationFrequency; }
+            set { _rotationFrequency = value; }
+        }
 
-		private Quaternion _initialRotation;
+        public float positionAmplitude {
+            get { return _positionAmplitude; }
+            set { _positionAmplitude = value; }
+        }
 
-		private float[] _time;
+        public float rotationAmplitude {
+            get { return _rotationAmplitude; }
+            set { _rotationAmplitude = value; }
+        }
 
-		public bool enablePositionNoise
-		{
-			get
-			{
-				return false;
-			}
-			set
-			{
-			}
-		}
+        public Vector3 positionScale {
+            get { return _positionScale; }
+            set { _positionScale = value; }
+        }
 
-		public bool enableRotationNoise
-		{
-			get
-			{
-				return false;
-			}
-			set
-			{
-			}
-		}
+        public Vector3 rotationScale {
+            get { return _rotationScale; }
+            set { _rotationScale = value; }
+        }
 
-		public float positionFrequency
-		{
-			get
-			{
-				return 0f;
-			}
-			set
-			{
-			}
-		}
+        public int positionFractalLevel {
+            get { return _positionFractalLevel; }
+            set { _positionFractalLevel = value; }
+        }
 
-		public float rotationFrequency
-		{
-			get
-			{
-				return 0f;
-			}
-			set
-			{
-			}
-		}
+        public int rotationFractalLevel {
+            get { return _rotationFractalLevel; }
+            set { _rotationFractalLevel = value; }
+        }
 
-		public float positionAmplitude
-		{
-			get
-			{
-				return 0f;
-			}
-			set
-			{
-			}
-		}
+        public void Rehash()
+        {
+            for (var i = 0; i < 6; i++)
+                _time[i] = Random.Range(-10000.0f, 0.0f);
+        }
 
-		public float rotationAmplitude
-		{
-			get
-			{
-				return 0f;
-			}
-			set
-			{
-			}
-		}
+        #endregion
 
-		public Vector3 positionScale
-		{
-			get
-			{
-				return default(Vector3);
-			}
-			set
-			{
-			}
-		}
+        #region Private Members
 
-		public Vector3 rotationScale
-		{
-			get
-			{
-				return default(Vector3);
-			}
-			set
-			{
-			}
-		}
+        const float _fbmNorm = 1 / 0.75f;
 
-		public int positionFractalLevel
-		{
-			get
-			{
-				return 0;
-			}
-			set
-			{
-			}
-		}
+        Vector3 _initialPosition;
+        Quaternion _initialRotation;
+        float[] _time;
 
-		public int rotationFractalLevel
-		{
-			get
-			{
-				return 0;
-			}
-			set
-			{
-			}
-		}
+        #endregion
 
-		public void Rehash()
-		{
-		}
+        #region MonoBehaviour Functions
 
-		private void Start()
-		{
-		}
+        void Start()
+        {
+            _time = new float[6];
+            Rehash();
+        }
 
-		private void OnEnable()
-		{
-		}
+        void OnEnable()
+        {
+            _initialPosition = transform.localPosition;
+            _initialRotation = transform.localRotation;
+        }
 
-		private void Update()
-		{
-		}
-	}
+        void Update()
+        {
+            var dt = Time.deltaTime;
+
+            if (_enablePositionNoise)
+            {
+                for (var i = 0; i < 3; i++)
+                    _time[i] += _positionFrequency * dt;
+
+                var n = new Vector3(
+                    Perlin.Fbm(_time[0], _positionFractalLevel),
+                    Perlin.Fbm(_time[1], _positionFractalLevel),
+                    Perlin.Fbm(_time[2], _positionFractalLevel));
+
+                n = Vector3.Scale(n, _positionScale);
+                n *= _positionAmplitude * _fbmNorm;
+
+                transform.localPosition = _initialPosition + n;
+            }
+
+            if (_enableRotationNoise)
+            {
+                for (var i = 0; i < 3; i++)
+                    _time[i + 3] += _rotationFrequency * dt;
+
+                var n = new Vector3(
+                    Perlin.Fbm(_time[3], _rotationFractalLevel),
+                    Perlin.Fbm(_time[4], _rotationFractalLevel),
+                    Perlin.Fbm(_time[5], _rotationFractalLevel));
+
+                n = Vector3.Scale(n, _rotationScale);
+                n *= _rotationAmplitude * _fbmNorm;
+
+                transform.localRotation =
+                    Quaternion.Euler(n) * _initialRotation;
+            }
+        }
+
+        #endregion
+    }
 }

--- a/Scripts/Assembly-CSharp/Klak/Motion/ConstantMotion.cs
+++ b/Scripts/Assembly-CSharp/Klak/Motion/ConstantMotion.cs
@@ -1,149 +1,178 @@
+//
+// Klak - Utilities for creative coding with Unity
+//
+// Copyright (C) 2016 Keijiro Takahashi
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
 using UnityEngine;
 
 namespace Klak.Motion
 {
-	public class ConstantMotion : MonoBehaviour
-	{
-		public enum TranslationMode
-		{
-			Off = 0,
-			XAxis = 1,
-			YAxis = 2,
-			ZAxis = 3,
-			Vector = 4,
-			Random = 5
-		}
+    [AddComponentMenu("Klak/Motion/Constant Motion")]
+    public class ConstantMotion : MonoBehaviour
+    {
+        #region Nested Classes
 
-		public enum RotationMode
-		{
-			Off = 0,
-			XAxis = 1,
-			YAxis = 2,
-			ZAxis = 3,
-			Vector = 4,
-			Random = 5
-		}
+        public enum TranslationMode {
+            Off, XAxis, YAxis, ZAxis, Vector, Random
+        };
 
-		[SerializeField]
-		private TranslationMode _translationMode;
+        public enum RotationMode {
+            Off, XAxis, YAxis, ZAxis, Vector, Random
+        }
 
-		[SerializeField]
-		private Vector3 _translationVector;
+        #endregion
 
-		[SerializeField]
-		private float _translationSpeed;
+        #region Editable Properties
 
-		[SerializeField]
-		private RotationMode _rotationMode;
+        [SerializeField]
+        TranslationMode _translationMode = TranslationMode.Off;
 
-		[SerializeField]
-		private Vector3 _rotationAxis;
+        [SerializeField]
+        Vector3 _translationVector = Vector3.forward;
 
-		[SerializeField]
-		private float _rotationSpeed;
+        [SerializeField]
+        float _translationSpeed = 1.0f;
 
-		[SerializeField]
-		private bool _useLocalCoordinate;
+        [SerializeField]
+        RotationMode _rotationMode = RotationMode.Off;
 
-		private MeshRenderer mesh;
+        [SerializeField]
+        Vector3 _rotationAxis = Vector3.up;
 
-		private bool isVis;
+        [SerializeField]
+        float _rotationSpeed = 30.0f;
 
-		private Vector3 _randomVectorT;
+        [SerializeField]
+        bool _useLocalCoordinate = true;
 
-		private Vector3 _randomVectorR;
+        #endregion
 
-		private float dt;
+        #region Public Properties
 
-		private int willRender;
+        public TranslationMode translationMode {
+            get { return _translationMode; }
+            set { _translationMode = value; }
+        }
 
-		public TranslationMode translationMode
-		{
-			get
-			{
-				return default(TranslationMode);
-			}
-			set
-			{
-			}
-		}
+        public Vector3 translationVector {
+            get { return _translationVector; }
+            set { _translationVector = value; }
+        }
 
-		public Vector3 translationVector
-		{
-			get
-			{
-				return default(Vector3);
-			}
-			set
-			{
-			}
-		}
+        public float translationSpeed {
+            get { return _translationSpeed; }
+            set { _translationSpeed = value; }
+        }
 
-		public float translationSpeed
-		{
-			get
-			{
-				return 0f;
-			}
-			set
-			{
-			}
-		}
+        public RotationMode rotationMode {
+            get { return _rotationMode; }
+            set { _rotationMode = value; }
+        }
 
-		public RotationMode rotationMode
-		{
-			get
-			{
-				return default(RotationMode);
-			}
-			set
-			{
-			}
-		}
+        public Vector3 rotationAxis {
+            get { return _rotationAxis; }
+            set { _rotationAxis = value; }
+        }
 
-		public Vector3 rotationAxis
-		{
-			get
-			{
-				return default(Vector3);
-			}
-			set
-			{
-			}
-		}
+        public float rotationSpeed {
+            get { return _rotationSpeed; }
+            set { _rotationSpeed = value; }
+        }
 
-		public float rotationSpeed
-		{
-			get
-			{
-				return 0f;
-			}
-			set
-			{
-			}
-		}
+        public bool useLocalCoordinate {
+            get { return _useLocalCoordinate; }
+            set { _useLocalCoordinate = value; }
+        }
 
-		public bool useLocalCoordinate
-		{
-			get
-			{
-				return false;
-			}
-			set
-			{
-			}
-		}
+        #endregion
 
-		private Vector3 TranslationVector => default(Vector3);
+        #region Private Variables
 
-		private Vector3 RotationVector => default(Vector3);
+        Vector3 _randomVectorT;
+        Vector3 _randomVectorR;
 
-		private void Start()
-		{
-		}
+        Vector3 TranslationVector {
+            get {
+                switch (_translationMode)
+                {
+                    case TranslationMode.XAxis:  return Vector3.right;
+                    case TranslationMode.YAxis:  return Vector3.up;
+                    case TranslationMode.ZAxis:  return Vector3.forward;
+                    case TranslationMode.Vector: return _translationVector;
+                }
+                // TranslationMode.Random
+                return _randomVectorT;
+            }
+        }
 
-		public void OnWillRenderObject()
-		{
-		}
-	}
+        Vector3 RotationVector {
+            get {
+                switch (_rotationMode)
+                {
+                    case RotationMode.XAxis:  return Vector3.right;
+                    case RotationMode.YAxis:  return Vector3.up;
+                    case RotationMode.ZAxis:  return Vector3.forward;
+                    case RotationMode.Vector: return _rotationAxis;
+                }
+                // RotationMode.Random
+                return _randomVectorR;
+            }
+        }
+
+        #endregion
+
+        #region MonoBehaviour Functions
+
+        void Start()
+        {
+            _randomVectorT = Random.onUnitSphere;
+            _randomVectorR = Random.onUnitSphere;
+        }
+
+        void Update()
+        {
+            var dt = Time.deltaTime;
+
+            if (_translationMode != TranslationMode.Off)
+            {
+                var dp = TranslationVector * _translationSpeed * dt;
+
+                if (_useLocalCoordinate)
+                    transform.localPosition += dp;
+                else
+                    transform.position += dp;
+            }
+
+            if (_rotationMode != RotationMode.Off)
+            {
+                var dr = Quaternion.AngleAxis(
+                    _rotationSpeed * dt, RotationVector);
+
+                if (_useLocalCoordinate)
+                    transform.localRotation = dr * transform.localRotation;
+                else
+                    transform.rotation = dr * transform.rotation;
+            }
+        }
+
+        #endregion
+    }
 }


### PR DESCRIPTION
A couple things from Klak are unstripped and usable in-game. There's noise methods, as well as scripts for object motion that'd be great to have working in-editor. They're licensed under [MIT](https://github.com/keijiro/Klak/blob/master/LICENSE.md), so free stuff!

A search via `dnspy` and Unity Explorer shows what's available for use:

<img width="245" height="56" alt="image" src="https://github.com/user-attachments/assets/d8ba2f77-e59b-4b42-90dd-055a855d63f1" />

<img width="984" height="1066" alt="image" src="https://github.com/user-attachments/assets/c05fbb39-c7c7-4251-88f2-6d3047ccea2a" />

This PR includes functional versions of what's available.